### PR TITLE
cleanup rocksdb options and batch

### DIFF
--- a/rocksdb/reader.go
+++ b/rocksdb/reader.go
@@ -21,6 +21,7 @@ type Reader struct {
 
 func (r *Reader) Get(key []byte) ([]byte, error) {
 	options := defaultReadOptions()
+	defer options.Destroy()
 	options.SetSnapshot(r.snapshot)
 	b, err := r.store.db.Get(options, key)
 	if err != nil {
@@ -38,6 +39,7 @@ func (r *Reader) PrefixIterator(prefix []byte) store.KVIterator {
 		prefix:   prefix,
 	}
 	rv.Seek(prefix)
+	options.Destroy()
 	return &rv
 }
 
@@ -51,6 +53,7 @@ func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
 		end:      end,
 	}
 	rv.Seek(start)
+	options.Destroy()
 	return &rv
 }
 

--- a/rocksdb/writer.go
+++ b/rocksdb/writer.go
@@ -35,6 +35,7 @@ func (w *Writer) ExecuteBatch(b store.KVBatch) error {
 
 	wopts := defaultWriteOptions()
 	err := w.store.db.Write(wopts, batch.batch)
+	wopts.Destroy()
 	return err
 }
 


### PR DESCRIPTION
The rocksb Batch instances were leaking.

An even stronger fix (not part of this PR) might be that bleve.index.store.KVBatch interface should have a Close() method, but would need @mschoch's thoughts on that and that would be a larger fix/change that could be done later?

I also saw that github.com/tecbot/gorocksdb had some Destroy() methods on the various read-options and write-options, so seemed like they should be called during cleanup.

