### PR TITLE
WIP perf 2016/01/18

### DIFF
--- a/forestdb/writer.go
+++ b/forestdb/writer.go
@@ -31,8 +31,14 @@ func (w *Writer) NewBatch() store.KVBatch {
 }
 
 func (w *Writer) NewBatchEx(options store.KVBatchOptions) ([]byte, store.KVBatch, error) {
-	rv := newBatchEx(w, options)
-	return rv.buf, rv, nil
+	// TODO: Reverted use of newBatchEx() as there's a merge operator
+	// issue, with error message: "error executing batch: forestdb
+	// BatchEx merge operator failure".
+	//
+	// rv := newBatchEx(w, options)
+	// return rv.buf, rv, nil
+
+	return make([]byte, options.TotalBytes), w.NewBatch(), nil
 }
 
 func (w *Writer) ExecuteBatch(b store.KVBatch) error {


### PR DESCRIPTION
With the recent forestdb BatchEx optimization, we were seeing
occassional error messages from bleve-blast of...

    error executing batch: forestdb BatchEx merge operator failure

Going back to emulated batch until this is resolved.