### PR TITLE
WIP perf 2016/01/18-1

### DIFF
--- a/forestdb/writer.go
+++ b/forestdb/writer.go
@@ -31,14 +31,8 @@ func (w *Writer) NewBatch() store.KVBatch {
 }
 
 func (w *Writer) NewBatchEx(options store.KVBatchOptions) ([]byte, store.KVBatch, error) {
-	// TODO: Reverted use of newBatchEx() as there's a merge operator
-	// issue, with error message: "error executing batch: forestdb
-	// BatchEx merge operator failure".
-	//
-	// rv := newBatchEx(w, options)
-	// return rv.buf, rv, nil
-
-	return make([]byte, options.TotalBytes), w.NewBatch(), nil
+	rv := newBatchEx(w, options)
+	return rv.buf, rv, nil
 }
 
 func (w *Writer) ExecuteBatch(b store.KVBatch) error {


### PR DESCRIPTION
Fix for forestdb so that it can use the new cgo BatchEx optimization.  The fix is that the keys/vals for merges should not be GC'able (and inadvertently reusable) until the batch is done.