### PR TITLE
MB-19576 - forestdb can optionally skip batch transaction

### DIFF
--- a/forestdb/store.go
+++ b/forestdb/store.go
@@ -37,6 +37,8 @@ type Store struct {
 	statsMutex  sync.Mutex
 	statsHandle *forestdb.KVStore
 	stats       *kvStat
+
+	skipBatch bool
 }
 
 func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, error) {
@@ -87,6 +89,11 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 		}
 	}
 
+	var skipBatch bool
+	if skipBatchV, ok := config["skip_batch"].(bool); ok {
+		skipBatch = skipBatchV
+	}
+
 	rv := Store{
 		path:        path,
 		kvpool:      kvpool,
@@ -94,6 +101,7 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 		fdbConfig:   fdbConfig,
 		kvsConfig:   kvsConfig,
 		statsHandle: statsHandle,
+		skipBatch:   skipBatch,
 	}
 
 	rv.stats = &kvStat{s: &rv}

--- a/forestdb/writer.go
+++ b/forestdb/writer.go
@@ -71,6 +71,13 @@ func (w *Writer) ExecuteBatch(b store.KVBatch) error {
 		batch.Set(k, mergedVal)
 	}
 
+	if w.store.skipBatch {
+		if batch.skipBatchErr != nil {
+			return batch.skipBatchErr
+		}
+		return w.kvstore.File().Commit(forestdb.COMMIT_NORMAL)
+	}
+
 	return w.kvstore.ExecuteBatch(batch.batch, forestdb.COMMIT_NORMAL)
 }
 


### PR DESCRIPTION
When the forestdb store has been configured to "skip_batch" of true,
then the batch API no longer builds up an actual batch in a
transaction as its approach, but instead performs direct, immediate
forestdb Set()/Delete()'s and uses commit() at the end of the
ExecuteBatch().

This allows higher-level layers (such as moss) to use this feature,
along with snapshots, in order to avoid extra memory overhead when the
batches get very large with forestdb.