### PR TITLE
Fix Copy&Paste error

### DIFF
--- a/lang/de/analyzer_de.go
+++ b/lang/de/analyzer_de.go
@@ -27,7 +27,7 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	stopDeFilter, err := cache.TokenFilterNamed(NormalizeName)
+	stopDeFilter, err := cache.TokenFilterNamed(StopName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We were loading the same filter twice by mistake.