### PR TITLE
tebeka/snowball has been moved to github.com

### DIFF
--- a/stemmer/stemmer_filter.go
+++ b/stemmer/stemmer_filter.go
@@ -12,7 +12,7 @@ package stemmer
 import (
 	"fmt"
 
-	"bitbucket.org/tebeka/snowball"
+	"github.com/tebeka/snowball"
 	"github.com/blevesearch/bleve/analysis"
 	"github.com/blevesearch/bleve/registry"
 )


### PR DESCRIPTION
repository https://bitbucket.org/tebeka/snowball has been deleted.
It now lives at https://github.com/tebeka/snowball.