### PR TITLE
Add Compact() to leveldb and rocksdb stores

### DIFF
--- a/leveldb/store.go
+++ b/leveldb/store.go
@@ -81,6 +81,11 @@ func (s *Store) Writer() (store.KVWriter, error) {
 	}, nil
 }
 
+func (s *Store) Compact() error {
+	s.db.CompactRange(levigo.Range{})
+	return nil
+}
+
 func init() {
 	registry.RegisterKVStore(Name, New)
 }

--- a/rocksdb/store.go
+++ b/rocksdb/store.go
@@ -134,6 +134,11 @@ func (s *Store) Writer() (store.KVWriter, error) {
 	}, nil
 }
 
+func (s *Store) Compact() error {
+	s.db.CompactRange(gorocksdb.Range{})
+	return nil
+}
+
 func init() {
 	registry.RegisterKVStore(Name, New)
 }


### PR DESCRIPTION
Similar to methods added for goleveldb and boltdb, but without the DictionaryTerm cleanup.

cc https://github.com/blevesearch/bleve/issues/374 https://github.com/blevesearch/bleve/issues/363