### PR TITLE
Workaround for leveldb compaction bug

### DIFF
--- a/leveldb/store.go
+++ b/leveldb/store.go
@@ -82,6 +82,12 @@ func (s *Store) Writer() (store.KVWriter, error) {
 }
 
 func (s *Store) Compact() error {
+	// workaround for google/leveldb#227
+	// NULL batch means just wait for earlier writes to be done
+	err := s.db.Write(defaultWriteOptions(), &levigo.WriteBatch{})
+	if err != nil {
+		return err
+	}
 	s.db.CompactRange(levigo.Range{})
 	return nil
 }


### PR DESCRIPTION
There appears to be a long-standing known issue in leveldb where `CompactRange()` doesn't work in certain cases: https://github.com/google/leveldb/issues/227

This patch adds a workaround similar to the one found in Chromium: https://src.chromium.org/viewvc/chrome/trunk/src/content/browser/indexed_db/leveldb/leveldb_database.cc?r1=284313&r2=284312&pathrev=284313