### PR TITLE
leveldb: hack to delete while merging (to avoid manual compaction)

### DIFF
--- a/leveldb/writer.go
+++ b/leveldb/writer.go
@@ -10,6 +10,7 @@
 package leveldb
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/blevesearch/bleve/index/store"
@@ -63,7 +64,12 @@ func (w *Writer) ExecuteBatch(b store.KVBatch) error {
 		if !fullMergeOk {
 			return fmt.Errorf("unable to merge")
 		}
-		batch.Set(k, mergedVal)
+
+		if bytes.Equal(mergedVal, []byte{0}) {
+			batch.Delete(k)
+		} else {
+			batch.Set(k, mergedVal)
+		}
 	}
 
 	err := w.store.db.Write(w.options, batch.batch)


### PR DESCRIPTION
This is a hack I've been using in production for a couple years. It was discussed originally in https://github.com/blevesearch/blevex/pull/30

Just opening this PR to give it more visibility in case others using the leveldb backend run into the same problem.