### PR TITLE
chore: Bump ja tokenizer kagome from v1 to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/blevesearch/upsidedown_store_api v1.0.2
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d
 	github.com/golang/protobuf v1.3.2
-	github.com/ikawaha/kagome.ipadic v1.1.2
+	github.com/ikawaha/kagome-dict v1.0.9
+	github.com/ikawaha/kagome-dict/ipa v1.0.10
+	github.com/ikawaha/kagome/v2 v2.9.5
 	github.com/jmhodges/levigo v1.0.0
 	github.com/tebeka/snowball v0.4.2
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,12 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/ikawaha/kagome.ipadic v1.1.2 h1:pFxZ1PpMpc6ZoBK712YN5cVK0u/ju2DZ+gRIOriJFFs=
-github.com/ikawaha/kagome.ipadic v1.1.2/go.mod h1:DPSBbU0czaJhAb/5uKQZHMc9MTVRpDugJfX+HddPHHg=
+github.com/ikawaha/kagome-dict v1.0.9 h1:1Gg735LbBYsdFu13fdTvW6eVt0qIf5+S2qXGJtlG8C0=
+github.com/ikawaha/kagome-dict v1.0.9/go.mod h1:mn9itZLkFb6Ixko7q8eZmUabHbg3i9EYewnhOtvd2RM=
+github.com/ikawaha/kagome-dict/ipa v1.0.10 h1:wk9I21yg+fKdL6HJB9WgGiyXIiu1VttumJwmIRwn0g8=
+github.com/ikawaha/kagome-dict/ipa v1.0.10/go.mod h1:rbaOKrF58zhtpV2+2sVZBj0sUSp9dVKPjr660MehJbs=
+github.com/ikawaha/kagome/v2 v2.9.5 h1:uIkf04UWhSrcKa/f6HO0GmXFrBE3kQ1xauyP9EbgBAU=
+github.com/ikawaha/kagome/v2 v2.9.5/go.mod h1:OYzxPG9dQSalvznlcLNR8TEKpPwzKhnZszw9LLbf7e8=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/json-iterator/go v0.0.0-20171115153421-f7279a603ede h1:YrgBGwxMRK0Vq0WSCWFaZUnTsrA/PZE/xs1QZh+/edg=

--- a/lang/ja/analyzer_ja_test.go
+++ b/lang/ja/analyzer_ja_test.go
@@ -28,14 +28,14 @@ func TestJaAnalyzer(t *testing.T) {
 				&analysis.Token{
 					Term:     []byte("こんにちは"),
 					Type:     analysis.Ideographic,
-					Position: 1,
+					Position: 0,
 					Start:    0,
 					End:      15,
 				},
 				&analysis.Token{
 					Term:     []byte("世界"),
 					Type:     analysis.Ideographic,
-					Position: 2,
+					Position: 1,
 					Start:    15,
 					End:      21,
 				},
@@ -47,7 +47,7 @@ func TestJaAnalyzer(t *testing.T) {
 				&analysis.Token{
 					Term:     []byte("カタカナ"),
 					Type:     analysis.Ideographic,
-					Position: 1,
+					Position: 0,
 					Start:    0,
 					End:      12,
 				},

--- a/lang/ja/ja_morph_kagome_test.go
+++ b/lang/ja/ja_morph_kagome_test.go
@@ -23,53 +23,56 @@ func TestKagome(t *testing.T) {
 		output analysis.TokenStream
 	}{
 		{
-			[]byte("こんにちは世界"),
-			analysis.TokenStream{
+			input: []byte("こんにちは世界"),
+			output: analysis.TokenStream{
 				{
 					Start:    0,
 					End:      15,
 					Term:     []byte("こんにちは"),
-					Position: 1,
+					Position: 0,
 					Type:     analysis.Ideographic,
 				},
 				{
 					Start:    15,
 					End:      21,
 					Term:     []byte("世界"),
-					Position: 2,
+					Position: 1,
 					Type:     analysis.Ideographic,
 				},
 			},
 		},
 		{
-			[]byte("関西国際空港"),
-			analysis.TokenStream{
+			input: []byte("関西国際空港"),
+			output: analysis.TokenStream{
 				{
 					Start:    0,
 					End:      6,
 					Term:     []byte("関西"),
-					Position: 1,
+					Position: 0,
 					Type:     analysis.Ideographic,
 				},
 				{
 					Start:    6,
 					End:      12,
 					Term:     []byte("国際"),
-					Position: 2,
+					Position: 1,
 					Type:     analysis.Ideographic,
 				},
 				{
 					Start:    12,
 					End:      18,
 					Term:     []byte("空港"),
-					Position: 3,
+					Position: 2,
 					Type:     analysis.Ideographic,
 				},
 			},
 		},
 	}
 
-	tokenizer := NewKagomeMorphTokenizer()
+	tokenizer, err := NewKagomeMorphTokenizer()
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, test := range tests {
 		actuals := tokenizer.Tokenize(test.input)
 


### PR DESCRIPTION
This pull request primarily focuses on updating the Kagome Japanese morphological analyzer in the Go programming language. The most significant changes include updating the Kagome library, modifying the tokenizer initialization, and adjusting token positions in tests.

Library update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L11-R13): Updated the Kagome library from `github.com/ikawaha/kagome.ipadic v1.1.2` to `github.com/ikawaha/kagome-dict v1.0.9`, `github.com/ikawaha/kagome-dict/ipa v1.0.10`, and `github.com/ikawaha/kagome/v2 v2.9.5`.

Tokenizer initialization:

* [`lang/ja/ja_morph_kagome.go`](diffhunk://#diff-aa7de309d4b4f896a1af2b82ed13267411551e6dbc94834fe0cb2f37e476b7c0R13-R70): The `NewKagomeMorphTokenizer` and `NewKagomeMorphTokenizerWithUserDic` functions now return an error if the tokenizer fails to initialize. The tokenizer initialization now uses the `ipa.DictShrink()` function instead of `tokenizer.SysDic()`.

Token positions in tests:

* `lang/ja/analyzer_ja_test.go` and `lang/ja/ja_morph_kagome_test.go`: Token positions in tests have been adjusted to start from 0 instead of 1. [[1]](diffhunk://#diff-bd3b5fa93fc94ac0879a957e38a42c8850e21d7dd13a01ac68834a41b0c64bf8L31-R38) [[2]](diffhunk://#diff-bd3b5fa93fc94ac0879a957e38a42c8850e21d7dd13a01ac68834a41b0c64bf8L50-R50) [[3]](diffhunk://#diff-acb5b13ee1763169efe6993acf9bc5fde2c4be186264c0c4ee4885bb57c1bdbcL26-R75)